### PR TITLE
Add full support for Play 2.6

### DIFF
--- a/play/src/main/scala/io/opentracing/play/RequestAttributesSpanTagger.scala
+++ b/play/src/main/scala/io/opentracing/play/RequestAttributesSpanTagger.scala
@@ -1,0 +1,25 @@
+package io.opentracing.play
+
+import io.opentracing.Span
+import play.api.libs.typedmap.TypedKey
+import play.api.mvc.{RequestHeader, Result}
+
+/**
+ * Applies attributes from [[RequestHeader#attrs]].
+ *
+ * @param attributeKeys The set of attributes to read from the [[RequestHeader]]. Must be explicitly stated because
+ *  [[RequestHeader#attrs]] does not support iterating over all attributes on a request.
+ *
+ *  Attributes may or may not have a displayName. In order to ensure that the tags set on the Span are sensible, only
+ *  Attributes with a displayName set will be used to tag the Span.
+ */
+class RequestAttributesSpanTagger(attributeKeys: Set[TypedKey[String]]) extends SpanTagger {
+
+  def tag(span: Span, request: RequestHeader, result: Result) = {
+    attributeKeys.foreach { key =>
+      key.displayName.foreach { name =>
+        request.attrs.get(key).foreach(value => span.setTag(s"play.$name", value))
+      }
+    }
+  }
+}

--- a/play/src/main/scala/io/opentracing/play/TagsSpanTagger.scala
+++ b/play/src/main/scala/io/opentracing/play/TagsSpanTagger.scala
@@ -6,6 +6,7 @@ import play.api.mvc.{RequestHeader, Result}
 /**
  * Applies tags from [[RequestHeader#tags]]
  */
+@deprecated("Tags are deprecated in Play 2.6; use RequestAttributesSpanTagger instead", "0.14")
 class TagsSpanTagger(include: String => Boolean) extends SpanTagger {
   def tag(span: Span, request: RequestHeader, result: Result) = {
     request.tags.foreach { case (key, value) => if (include(key)) span.setTag(s"play.$key", value) }


### PR DESCRIPTION
Deprecated tag-based TagsSpanTagger. Tags are deprecated in Play 2.6 and removed in Play 2.7. Replaced TagsSpanTagger with RequestAttributesSpanTagger. This allows an easy migration on Play 2.6 and enables future Play 2.7 support.