### PR TITLE
[ci skip] correct ClassName in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To propagate the thread-local span, add [akka-thread-context](https://github.com
 a dependency and configure Akka to use `DispatchConfigurator`.
 
 ```hocon
-akka.actor.default-dispatcher.type = com.lucidchart.akka.threadcontext.DefaultDispatchConfigurator
+akka.actor.default-dispatcher.type = com.lucidchart.akka.threadcontext.DefaultDispatcherConfigurator
 ```
 
 ### Add filters


### PR DESCRIPTION
As discovered while I was testing this out on Yahoo's kafka-manager.